### PR TITLE
change prev_pid-parameter assingment

### DIFF
--- a/ocrd_olahd_client/ocrd-tool.json
+++ b/ocrd_olahd_client/ocrd-tool.json
@@ -33,6 +33,11 @@
           "description": "Password",
           "type": "string",
           "required": true
+        },
+        "pid_previous_version": {
+          "description": "PID of the previous version of this work, already stored in OLA-HD",
+          "type": "string",
+          "required": false
         }
       }
     }

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -35,5 +35,6 @@ class OlaHdClientProcessor(Processor):
         LOG.debug('Logging in')
         client.login()
         LOG.debug('POST bag')
-        client.post(dest, prev_pid=ocrd_identifier)
+        prev_pid = self.parameter.get('pid_previous_version', None)
+        client.post(dest, prev_pid=prev_pid)
         LOG.info('finished POST bag')


### PR DESCRIPTION
I think it is reasonable what I think was intended here: provide the ocrd_identifier and if this is already stored inside olahd then set this bag as a new version of that work. But that is not how olahd currently works: the PID of the previous version must be provided (A PID is "generated" when an ocrd-zip is imported into olahd). This request with the ocrd_identifier must fail in nearly any case, because the ocr-d identifier is usually not a PID especially not the PID the related ocrd-zip already stored in OLA-HD. If a ocrd_zip is imported with a "PID-previous-version" provided which does not exists then an error is raised and OLA-HD denys the import request. So this change is necessary to actually make it work.