### PR TITLE
reset input filegrp

### DIFF
--- a/ocrd_olahd_client/cli.py
+++ b/ocrd_olahd_client/cli.py
@@ -6,4 +6,6 @@ from .processor import OlaHdClientProcessor
 @click.command()
 @ocrd_cli_options
 def cli(*args, **kwargs):
+    if kwargs['input_file_grp'] == 'INPUT':
+        kwargs['input_file_grp'] = ''
     return ocrd_cli_wrap_processor(OlaHdClientProcessor, *args, **kwargs)

--- a/ocrd_olahd_client/ocrd-tool.json
+++ b/ocrd_olahd_client/ocrd-tool.json
@@ -33,6 +33,11 @@
           "description": "Password",
           "type": "string",
           "required": true
+        },
+        "pid_previous_version": {
+          "description": "PID of the previous version of this work, already stored in OLA-HD",
+          "type": "string",
+          "required": false
         }
       }
     }

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -35,5 +35,6 @@ class OlaHdClientProcessor(Processor):
         LOG.debug('Logging in')
         client.login()
         LOG.debug('POST bag')
-        client.post(dest, prev_pid=ocrd_identifier)
+        prev_pid = self.parameter.get('pid_previous_version', None)
+        client.post(dest, prev_pid=prev_pid)
         LOG.info('finished POST bag')


### PR DESCRIPTION
Currently when just executing the upload reaquest without specifying a file grp it fails when 'INPUT' file-grp is not present in the workspace. 'INPUT' is the default value for input-file-grp. 

Maybe it would be better to first ensure that no file-grp is provided and that the default value is present and only then remove it. But my goal is to simply make it work for now and the file-grp is not used anyway.