### PR TITLE
Inform the user about PID after upload (print PID)

### DIFF
--- a/ocrd_olahd_client/cli.py
+++ b/ocrd_olahd_client/cli.py
@@ -6,4 +6,6 @@ from .processor import OlaHdClientProcessor
 @click.command()
 @ocrd_cli_options
 def cli(*args, **kwargs):
+    if kwargs['input_file_grp'] == 'INPUT':
+        kwargs['input_file_grp'] = ''
     return ocrd_cli_wrap_processor(OlaHdClientProcessor, *args, **kwargs)

--- a/ocrd_olahd_client/client.py
+++ b/ocrd_olahd_client/client.py
@@ -25,7 +25,7 @@ class OlaHdClient():
             r.raise_for_status()
         self.token = r.json()['accessToken']
 
-    def post(self, bag_fpath, prev_pid=None):
+    def post(self, bag_fpath, prev_pid=None) -> str:
         if not self.is_logged_in():
             raise Exception("Not logged in")
         fields={'file': ('file.zip', open(bag_fpath, 'rb'), 'application/vnd.ocrd+zip')}
@@ -40,4 +40,4 @@ class OlaHdClient():
         })
         if r.status_code >= 400:
             r.raise_for_status()
-        return r.json()
+        return r.json()['pid']

--- a/ocrd_olahd_client/ocrd-tool.json
+++ b/ocrd_olahd_client/ocrd-tool.json
@@ -33,6 +33,11 @@
           "description": "Password",
           "type": "string",
           "required": true
+        },
+        "pid_previous_version": {
+          "description": "PID of the previous version of this work, already stored in OLA-HD",
+          "type": "string",
+          "required": false
         }
       }
     }

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -36,5 +36,6 @@ class OlaHdClientProcessor(Processor):
         client.login()
         LOG.debug('POST bag')
         prev_pid = self.parameter.get('pid_previous_version', None)
-        client.post(dest, prev_pid=prev_pid)
+        pid = client.post(dest, prev_pid=prev_pid)
+        print(f"PID of uploaded workspace: {pid}")
         LOG.info('finished POST bag')

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -35,5 +35,6 @@ class OlaHdClientProcessor(Processor):
         LOG.debug('Logging in')
         client.login()
         LOG.debug('POST bag')
-        client.post(dest, prev_pid=ocrd_identifier)
+        prev_pid = self.parameter.get('pid_previous_version', None)
+        client.post(dest, prev_pid=prev_pid)
         LOG.info('finished POST bag')


### PR DESCRIPTION
After uploading a workspace with the processor the request returns a PID. The user can use it to download or reference the uploaded workspace. In my opinion this PID must at least be printed so the user can store it somewhere. I am not sure though if it should just be printed "alone", printed with a message like I implemented it (eg: `PID of uploaded workspace: 21.T11998/0000-001C-9DB8-2`) or if it should be printed by the logger.