### PR TITLE
Manipulate mets-agent output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ install:
 	$(PIP) install -U pip
 	$(PIP) install .
 
+# Install-develop
+install-dev:
+	$(PIP) install -U pip
+	$(PIP) install -e .
+
 # Build docker image
 docker:
 	docker build -t $(DOCKER_TAG) .

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -43,4 +43,4 @@ class OlaHdClientProcessor(Processor):
         if "password" in self.parameter:
             self.parameter["password"] = "*****"
         if pid:
-            self.parameter["result_pid"] = pid
+            self.parameter["pid_previous_version"] = pid

--- a/ocrd_olahd_client/processor.py
+++ b/ocrd_olahd_client/processor.py
@@ -14,6 +14,7 @@ from .client import OlaHdClient
 OCRD_TOOL = json.loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))
 TOOL = 'ocrd-olahd-client'
 
+
 class OlaHdClientProcessor(Processor):
 
     def __init__(self, *args, **kwargs):
@@ -24,7 +25,8 @@ class OlaHdClientProcessor(Processor):
     def process(self):
         LOG = getLogger('processor.OlaHdClientProcessor')
         LOG.info('Posting workspace to %s' % self.parameter['endpoint'])
-        client = OlaHdClient(self.parameter['endpoint'], self.parameter['username'], self.parameter['password'])
+        client = OlaHdClient(self.parameter['endpoint'], self.parameter['username'],
+                             self.parameter['password'])
         bagger = WorkspaceBagger(Resolver(), strict=True)
         # TODO
         dest = join(gettempdir(), 'bag-%d.ocrd.zip' % int(round((time() * 1000))))
@@ -38,3 +40,7 @@ class OlaHdClientProcessor(Processor):
         prev_pid = self.parameter.get('pid_previous_version', None)
         pid = client.post(dest, prev_pid=prev_pid)
         LOG.info(f"finished POST bag. Received PID: {pid}")
+        if "password" in self.parameter:
+            self.parameter["password"] = "*****"
+        if pid:
+            self.parameter["result_pid"] = pid


### PR DESCRIPTION
Ocr-d core inserts a mets-agent to the metsfile after executing a processor. This entry contains all parameters provided to the processor. For olahd the password should not be printed and the mets-agent is used (kind of missued maybe) to store the pid of the send bagit.

No core-update is needed for that change to take effect.