### PR TITLE
Fix pytests failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ ocrd-olahd-client = "ocrd_olahd_client.cli:cli"
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]
+
+[tool.pytest.ini_options]
+pythonpath = "src"


### PR DESCRIPTION
Tests do not run because of `ModuleNotFoundError`. My fix fixes that. I am not sure though if that is the right way to do it with pyprojects.toml (maybe another option is better I don't know much about python building).